### PR TITLE
Remove required objects from response schema of /v1/provide-equipment…

### DIFF
--- a/spec/AccessPlanningToolProxy.yaml
+++ b/spec/AccessPlanningToolProxy.yaml
@@ -6859,10 +6859,6 @@ paths:
             application/json:
               schema:
                 type: object
-                required:
-                  - radio
-                  - modem
-                  - device
                 properties:
                   radio:
                     type: object


### PR DESCRIPTION
Update of the specification, if this is okay with you,

Fixes #321 

This way, returning objects with empty properties would be avoided. Example, the modem object would not be returned:

{
"radio": {
"equipment-name": "ASN-18G",
"serial-number": "10148702300043B",
"part-number": "GE8704"
},
**"modem": {
"equipment-name": "",
"serial-number": "",
"part-number": ""
},**
"device": {
"equipment-name": "ALCPlus2e",
"serial-number": "14209652001003620",
"part-number": "GAI0182"
}
}